### PR TITLE
Fix bootstrap getting stuck by using proper initial priority for fron…

### DIFF
--- a/node/src/bootstrap/state/bootstrap_state.rs
+++ b/node/src/bootstrap/state/bootstrap_state.rs
@@ -88,9 +88,9 @@ impl BootstrapState {
         self.counters.outdated_accounts_found += outdated.accounts.len();
 
         for account in &outdated.accounts {
-            // Use the lowest possible priority here
+            // Use initial priority to give accounts multiple retry attempts before eviction
             self.candidate_accounts
-                .priority_set(account, CandidateAccounts::PRIORITY_CUTOFF);
+                .priority_set(account, CandidateAccounts::PRIORITY_INITIAL);
 
             self.last_outdated_accounts.push_back(*account);
             if self.last_outdated_accounts.len() > 20 {


### PR DESCRIPTION
…tier-discovered accounts

Root cause: Frontier-discovered accounts were being added with PRIORITY_CUTOFF (0.15), which caused them to be immediately evicted after a single empty response (0.15/2 = 0.075 < 0.15). This created an endless churn of discovering and evicting accounts, preventing bootstrap progress.

Fix: Use PRIORITY_INITIAL (2.0) instead, giving these accounts ~4 retry attempts before eviction, matching the behavior of other account types. This allows bootstrap to make progress even with temporary network issues or slow peers.

The issue manifested as:
- Bootstrap getting stuck at specific block heights (97k, 115k)
- Continuous "finding and evicting reps" messages
- Requiring node restarts every 10 minutes to make progress