### PR TITLE
Fix TCP listener busy loop causing massive connection spam

### DIFF
--- a/network/src/tcp_listener.rs
+++ b/network/src/tcp_listener.rs
@@ -141,6 +141,8 @@ impl TcpListenerExt for Arc<TcpListener> {
                 let Ok((stream, _)) = listener.accept().await else {
                     warn!("Could not accept incoming connection");
                     self.network_adapter.accept_failure();
+                    // Sleep to prevent busy loop on persistent accept failures
+                    sleep(Duration::from_millis(100)).await;
                     continue;
                 };
 
@@ -149,14 +151,16 @@ impl TcpListenerExt for Arc<TcpListener> {
                     .network_adapter
                     .add(tcp_stream, ChannelDirection::Inbound)
                 {
-                    Ok(_) => {}
+                    Ok(_) => {
+                        // Small yield to allow other tasks to run, but don't throttle too much
+                        sleep(Duration::from_millis(1)).await;
+                    }
                     Err(e) => {
                         warn!("Could not accept incoming connection: {:?}", e);
+                        // Sleep briefly on channel add failures
+                        sleep(Duration::from_millis(10)).await;
                     }
                 };
-
-                // Sleep for a while to prevent busy loop
-                sleep(Duration::from_millis(10)).await;
             }
         };
 


### PR DESCRIPTION
Root cause: When listener.accept() failed, the code continued without sleeping, creating a tight busy loop that spammed "Could not accept incoming connection" errors hundreds of times per second. This caused:
- CPU waste on futile accept attempts
- Log spam making diagnosis difficult
- Connection instability preventing stable peer connections
- Bootstrap getting stuck due to inability to maintain connections

Additionally, the unconditional 10ms sleep after every successful connection limited the node to 100 connections/second, which was too restrictive during bootstrap when many peers need to connect.

Fixes:
1. Sleep 100ms after accept failures to prevent busy loop spam
2. Sleep 10ms after channel add failures
3. Reduce successful connection sleep to 1ms (up to 1000 connections/second)
4. Add explanatory comments for each sleep case

This resolves the "finding and evicting reps" cycle that was blocking bootstrap.